### PR TITLE
fix: compose healthchecks, readiness endpoint, and integration test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   python-server:
     build:

--- a/node-server/Dockerfile
+++ b/node-server/Dockerfile
@@ -2,6 +2,11 @@ FROM node:18-slim
 
 WORKDIR /app
 
+# Install curl for healthchecks
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends curl \
+	&& rm -rf /var/lib/apt/lists/*
+
 COPY package*.json ./
 
 RUN npm install

--- a/node-server/src/index.js
+++ b/node-server/src/index.js
@@ -10,6 +10,11 @@ app.use(cors());
 app.use(express.json());
 app.use(morgan('dev')); // Logging middleware
 
+// Readiness / root endpoint
+app.get('/', (req, res) => {
+  res.json({ message: 'Node server is ready', status: 'ok' });
+});
+
 // Error handling middleware
 app.use((err, req, res, next) => {
   console.error(err.stack);

--- a/python-server/Dockerfile
+++ b/python-server/Dockerfile
@@ -4,6 +4,11 @@ FROM python:3.9-slim
 # Set the working directory in the container
 WORKDIR /app
 
+# Install curl (used by compose healthcheck)
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends curl \
+	&& rm -rf /var/lib/apt/lists/*
+
 # Copy the dependencies file to the working directory
 COPY requirements.txt /app
 

--- a/scripts/check_endpoints.sh
+++ b/scripts/check_endpoints.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Quick integration test: curl important endpoints and assert 200
+set -eu -o pipefail
+
+HOST=${HOST:-localhost}
+PY_PORT=${PY_PORT:-8000}
+NODE_PORT=${NODE_PORT:-8001}
+
+echo "Checking Python server root: http://${HOST}:${PY_PORT}/"
+PY_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://${HOST}:${PY_PORT}/") || PY_CODE="000"
+echo " -> HTTP ${PY_CODE}"
+
+echo "Checking Node server root: http://${HOST}:${NODE_PORT}/"
+NODE_ROOT_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://${HOST}:${NODE_PORT}/") || NODE_ROOT_CODE="000"
+echo " -> HTTP ${NODE_ROOT_CODE}"
+
+echo "Checking Node server health: http://${HOST}:${NODE_PORT}/health"
+NODE_HEALTH_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://${HOST}:${NODE_PORT}/health") || NODE_HEALTH_CODE="000"
+echo " -> HTTP ${NODE_HEALTH_CODE}"
+
+OK=true
+if [ "${PY_CODE}" != "200" ]; then
+  echo "ERROR: Python root did not return 200"
+  OK=false
+fi
+if [ "${NODE_ROOT_CODE}" != "200" ]; then
+  echo "ERROR: Node root did not return 200"
+  OK=false
+fi
+if [ "${NODE_HEALTH_CODE}" != "200" ]; then
+  echo "ERROR: Node /health did not return 200"
+  OK=false
+fi
+
+if [ "$OK" = true ]; then
+  echo "All endpoint checks passed"
+  exit 0
+else
+  echo "One or more checks failed"
+  exit 2
+fi


### PR DESCRIPTION
Summary:\n- Removes deprecated top-level  from  to prevent warnings.\n- Adds a root readiness endpoint () to the Node server so  returns 200 for convenience and readiness checks.\n- Installs  in both  and  images so Usage:  docker compose [OPTIONS] COMMAND

Define and run multi-container applications with Docker

Options:
      --all-resources              Include all resources,
                                   even those not used by
                                   services
      --ansi string                Control when to print
                                   ANSI control characters
                                   ("never"|"always"|"auto") (default "auto")
      --compatibility              Run compose in backward
                                   compatibility mode
      --dry-run                    Execute command in dry
                                   run mode
      --env-file stringArray       Specify an alternate
                                   environment file
  -f, --file stringArray           Compose configuration files
      --parallel int               Control max
                                   parallelism, -1 for
                                   unlimited (default -1)
      --profile stringArray        Specify a profile to enable
      --progress string            Set type of progress
                                   output (auto, tty,
                                   plain, json, quiet)
      --project-directory string   Specify an alternate
                                   working directory
                                   (default: the path of
                                   the, first specified,
                                   Compose file)
  -p, --project-name string        Project name

Management Commands:
  bridge      Convert compose files into another model

Commands:
  attach      Attach local standard input, output, and error streams to a service's running container
  build       Build or rebuild services
  commit      Create a new image from a service container's changes
  config      Parse, resolve and render compose file in canonical format
  cp          Copy files/folders between a service container and the local filesystem
  create      Creates containers for a service
  down        Stop and remove containers, networks
  events      Receive real time events from containers
  exec        Execute a command in a running container
  export      Export a service container's filesystem as a tar archive
  images      List images used by the created containers
  kill        Force stop service containers
  logs        View output from containers
  ls          List running compose projects
  pause       Pause services
  port        Print the public port for a port binding
  ps          List containers
  publish     Publish compose application
  pull        Pull service images
  push        Push service images
  restart     Restart service containers
  rm          Removes stopped service containers
  run         Run a one-off command on a service
  scale       Scale services 
  start       Start services
  stats       Display a live stream of container(s) resource usage statistics
  stop        Stop services
  top         Display the running processes
  unpause     Unpause services
  up          Create and start containers
  version     Show the Docker Compose version information
  volumes     List volumes
  wait        Block until containers of all (or specified) services stop.
  watch       Watch build context for service and rebuild/refresh containers when files are updated

Run 'docker compose COMMAND --help' for more information on a command. healthchecks (which use ) work inside the containers.\n- Adds an integration test script: Checking Python server root: http://localhost:8000/
 -> HTTP 200
Checking Node server root: http://localhost:8001/
 -> HTTP 200
Checking Node server health: http://localhost:8001/health
 -> HTTP 200
All endpoint checks passed that verifies the main endpoints return HTTP 200.\n\nHow to test locally:\n1. Run #1 [internal] load local bake definitions
#1 reading from stdin 785B done
#1 DONE 0.0s

#2 [node-server internal] load build definition from Dockerfile
#2 transferring dockerfile: 296B done
#2 DONE 0.0s

#3 [python-server internal] load build definition from Dockerfile
#3 transferring dockerfile: 649B done
#3 DONE 0.0s

#4 [auth] library/node:pull token for registry-1.docker.io
#4 DONE 0.0s

#5 [auth] library/python:pull token for registry-1.docker.io
#5 DONE 0.0s

#6 [python-server internal] load metadata for docker.io/library/python:3.9-slim
#6 DONE 0.1s

#7 [node-server internal] load metadata for docker.io/library/node:18-slim
#7 DONE 0.1s

#8 [node-server internal] load .dockerignore
#8 transferring context: 108B done
#8 DONE 0.0s

#9 [python-server internal] load .dockerignore
#9 transferring context: 2B done
#9 DONE 0.0s

#10 [node-server 1/6] FROM docker.io/library/node:18-slim@sha256:f9ab18e354e6855ae56ef2b290dd225c1e51a564f87584b9bd21dd651838830e
#10 DONE 0.0s

#11 [python-server 1/5] FROM docker.io/library/python:3.9-slim@sha256:aeebfa2890da7819f1617ec9a5650669570ab0802e5f51063aa8b7499da1ed26
#11 DONE 0.0s

#12 [python-server internal] load build context
#12 transferring context: 37B done
#12 DONE 0.0s

#13 [node-server internal] load build context
#13 transferring context: 185B done
#13 DONE 0.0s

#14 [python-server 2/5] WORKDIR /app
#14 CACHED

#15 [python-server 4/5] COPY requirements.txt /app
#15 CACHED

#16 [python-server 3/5] RUN apt-get update 	&& apt-get install -y --no-install-recommends curl 	&& rm -rf /var/lib/apt/lists/*
#16 CACHED

#17 [python-server 5/5] RUN pip install --no-cache-dir -r requirements.txt
#17 CACHED

#18 [node-server 2/6] WORKDIR /app
#18 CACHED

#19 [node-server 3/6] RUN apt-get update 	&& apt-get install -y --no-install-recommends curl 	&& rm -rf /var/lib/apt/lists/*
#19 CACHED

#20 [node-server 4/6] COPY package*.json ./
#20 CACHED

#21 [node-server 5/6] RUN npm install
#21 CACHED

#22 [node-server 6/6] COPY . .
#22 CACHED

#23 [python-server] exporting to image
#23 exporting layers done
#23 writing image sha256:67aeca5a885255b1d6b129fe7cf6819d6c91fdbe54b56f72701389bd6dcd0ba9 done
#23 naming to docker.io/library/anythink-market-u7rcc4ah-python-server done
#23 DONE 0.0s

#24 [node-server] exporting to image
#24 exporting layers done
#24 writing image sha256:5a7c6217468d1c33614307ffc0e9debef78044a7d69ec3ad9d567c1a30040205 done
#24 naming to docker.io/library/anythink-market-u7rcc4ah-node-server done
#24 DONE 0.0s

#25 [node-server] resolving provenance for metadata file
#25 DONE 0.0s

#26 [python-server] resolving provenance for metadata file
#26 DONE 0.0s.\n2. Run Checking Python server root: http://localhost:8000/
 -> HTTP 200
Checking Node server root: http://localhost:8001/
 -> HTTP 200
Checking Node server health: http://localhost:8001/health
 -> HTTP 200
All endpoint checks passed (or let CI run it).\n3. Confirm NAME                                       IMAGE                                    COMMAND                  SERVICE         CREATED          STATUS                    PORTS
anythink-market-u7rcc4ah-node-server-1     anythink-market-u7rcc4ah-node-server     "docker-entrypoint.s…"   node-server     12 minutes ago   Up 12 minutes (healthy)   0.0.0.0:8001->3000/tcp, [::]:8001->3000/tcp
anythink-market-u7rcc4ah-python-server-1   anythink-market-u7rcc4ah-python-server   "uvicorn src.main:ap…"   python-server   12 minutes ago   Up 12 minutes (healthy)   0.0.0.0:8000->8000/tcp, [::]:8000->8000/tcp shows both services as .\n\nNotes:\n- The Node server now responds on  with a small JSON readiness response.\n- If you prefer healthchecks use a different binary (e.g., ) or a small python script, we can switch the healthcheck to that instead for smaller images.